### PR TITLE
add py option as python version

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -14,7 +14,8 @@ this.config = {
     default: 'python3',
     enum: [
       'python',
-      'python3'
+      'python3',
+      'py'
     ],
     order: 0
   },


### PR DESCRIPTION
The python launcher in a windows install can read the file's shebang (e.g. `#!/usr/bin/env python2.7`)  and can take version arguments like `-2` or `-3` to select the desired python version.

See [https://docs.python.org/3/using/windows.html#python-launcher-for-windows](https://docs.python.org/3/using/windows.html#python-launcher-for-windows)